### PR TITLE
解决 YYAsyncLayerGetDisplayQueue 函数可能出现的 BAD_ACCESS 问题

### DIFF
--- a/YYAsyncLayer/YYAsyncLayer.m
+++ b/YYAsyncLayer/YYAsyncLayer.m
@@ -43,8 +43,7 @@ static dispatch_queue_t YYAsyncLayerGetDisplayQueue() {
             }
         }
     });
-    int32_t cur = OSAtomicIncrement32(&counter);
-    if (cur < 0) cur = -cur;
+    uint32_t cur = (uint32_t)OSAtomicIncrement32(&counter);
     return queues[(cur) % queueCount];
 #undef MAX_QUEUE_COUNT
 #endif


### PR DESCRIPTION
解决 YYAsyncLayerGetDisplayQueue 函数的 counter 变量在自增至-2147483648时，可能会出现取数组下标为负，导致 EXC_BAD_ACCESS 的问题。
详情见 https://www.jianshu.com/p/349c7b9bd376